### PR TITLE
AMP-273 Relax case URN validation from 10-40 to 1-30 alphanumerics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,10 +46,10 @@ dependencies {
   implementation "org.owasp.encoder:encoder:1.4.0"
   testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-  compileOnly group: 'org.projectlombok', name: 'lombok', version: "1.18.44"
-  annotationProcessor group: 'org.projectlombok', name: 'lombok', version: "1.18.44"
-  testCompileOnly group: 'org.projectlombok', name: 'lombok', version: "1.18.44"
-  testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: "1.18.44"
+  compileOnly "org.projectlombok:lombok:1.18.44"
+  annotationProcessor "org.projectlombok:lombok:1.18.44"
+  testCompileOnly "org.projectlombok:lombok:1.18.44"
+  testAnnotationProcessor "org.projectlombok:lombok:1.18.44"
 
   implementation "org.mapstruct:mapstruct:1.6.3"
   annotationProcessor "org.mapstruct:mapstruct-processor:1.6.3"

--- a/src/main/java/uk/gov/hmcts/cp/controllers/CaseUrnMapperController.java
+++ b/src/main/java/uk/gov/hmcts/cp/controllers/CaseUrnMapperController.java
@@ -17,7 +17,7 @@ import uk.gov.hmcts.cp.services.CaseUrnMapperService;
 @RequiredArgsConstructor
 public class CaseUrnMapperController implements CaseIdByCaseUrnApi {
 
-    private static final String CASE_URN_REGEX = "^[0-9a-zA-Z]{10,40}$";
+    private static final String CASE_URN_REGEX = "^[0-9a-zA-Z]{1,30}$";
     private final CaseUrnMapperService caseUrnMapperService;
     private CaseMapperResponse response;
 
@@ -34,7 +34,7 @@ public class CaseUrnMapperController implements CaseIdByCaseUrnApi {
     private String validateCaseUrn(final String caseUrn) {
         if (caseUrn == null || !caseUrn.matches(CASE_URN_REGEX)) {
             log.info("CaseUrn {} does not match expected caseRegex:{}", Encode.forJava(caseUrn), CASE_URN_REGEX);
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Case urn must be between 10 and 40 alphanumerics");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Case urn must be between 1 and 30 alphanumerics");
         }
         return caseUrn;
     }

--- a/src/test/java/uk/gov/hmcts/cp/controllers/CaseUrnMapperControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/controllers/CaseUrnMapperControllerTest.java
@@ -26,12 +26,10 @@ class CaseUrnMapperControllerTest {
     void controller_should_validate_case_urn() {
         assertThrows(ResponseStatusException.class, () -> caseUrnMapperController.getCaseIdByCaseUrn(null, true));
         assertThrows(ResponseStatusException.class, () -> caseUrnMapperController.getCaseIdByCaseUrn("", true));
-        assertThrows(ResponseStatusException.class, () -> caseUrnMapperController.getCaseIdByCaseUrn("LESTHAN10", true));
         assertThrows(ResponseStatusException.class, () -> caseUrnMapperController.getCaseIdByCaseUrn("NONEALPHANUM-", true));
         assertThrows(ResponseStatusException.class, () -> caseUrnMapperController.getCaseIdByCaseUrn("NONEALPHANUM ", true));
         assertThrows(ResponseStatusException.class, () -> caseUrnMapperController.getCaseIdByCaseUrn("NONE ALPHANUM", true));
-        assertThrows(ResponseStatusException.class, () -> caseUrnMapperController.getCaseIdByCaseUrn("A".repeat(9), true));
-        assertThrows(ResponseStatusException.class, () -> caseUrnMapperController.getCaseIdByCaseUrn("A".repeat(41), true));
+        assertThrows(ResponseStatusException.class, () -> caseUrnMapperController.getCaseIdByCaseUrn("A".repeat(31), true));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/cp/integration/ValidationIntegrationTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/integration/ValidationIntegrationTest.java
@@ -21,20 +21,20 @@ class ValidationIntegrationTest {
     private MockMvc mockMvc;
 
     @Test
-    void short_case_urn_should_throw_400() throws Exception {
-        mockMvc.perform(get("/urnmapper/{case_urn}?refresh=true", "short"))
+    void non_alphanumeric_case_urn_should_throw_400() throws Exception {
+        mockMvc.perform(get("/urnmapper/{case_urn}?refresh=true", "short-urn"))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("Case urn must be between 10 and 40 alphanumerics"));
+                .andExpect(jsonPath("$.message").value("Case urn must be between 1 and 30 alphanumerics"));
     }
 
     @Test
     void long_case_urn_should_throw_400() throws Exception {
-        String longCaseUrn = String.format("%41d", 1);
+        String longCaseUrn = "A".repeat(31);
         mockMvc.perform(get("/urnmapper/{case_urn}?refresh=true", longCaseUrn))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("Case urn must be between 10 and 40 alphanumerics"));
+                .andExpect(jsonPath("$.message").value("Case urn must be between 1 and 30 alphanumerics"));
     }
 
     @Test


### PR DESCRIPTION
## JIRA
  [AMP-273](https://tools.hmcts.net/jira/browse/AMP-273)

  ## What changed
  - Changed case URN validation regex in `CaseUrnMapperController` from `{10,40}` to `{1,30}` alphanumerics
  - Updated the 400 error message to match the new bounds: "Case urn must be between 1 and 30 alphanumerics"
  - Updated unit tests in `CaseUrnMapperControllerTest` to reflect removed minimum-length floor and new maximum of 30 characters
  - Standardised Lombok dependency declarations in `build.gradle` to shorthand `"group:name:version"` format
  
  ## Why it's needed
  The previous minimum of 10 characters was too restrictive for valid case URNs in production data. The upper bound has also been tightened from 40 to 30 to align with
   the expected URN format.
   
   the expected URN format.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
