### PR TITLE
chore: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,65 @@
+# Security Policy
+
+## Purpose
+
+This document outlines how security vulnerabilities should be reported for this
+repository.
+
+HMCTS is committed to responsible vulnerability disclosure and to addressing
+legitimate security issues in a timely and coordinated manner.
+
+## Reporting a vulnerability
+
+If you believe you have identified a security vulnerability in this repository, please report it by email to: 
+
+HMCTSVulnerabilityDisclosure@justice.gov.uk
+
+This email address is the sole approved point of contact for vulnerability disclosures relating to HMCTS-owned repositories and services.
+
+Please **do not** create public GitHub issues or pull requests to report security vulnerabilities.
+
+## What to Include in a Report
+
+When reporting a vulnerability, please provide as much of the following information as possible:
+
+- The repository, service, or component affected
+- A clear description of the vulnerability
+- Steps required to reproduce the issue
+- Any non-destructive proof of concept or exploitation details
+
+Where available, the following additional information is helpful:
+
+- The suspected vulnerability type (for example, an OWASP category)
+- Relevant logs, screenshot or error messages
+
+Reports do not need to be fully validated before submission. If you are unsure whether an issue is exploitable or security-relevant, you are still encouraged to report it.
+
+## Responsible Disclosure Guidelines
+
+When investigating or reporting a vulnerability affecting HMCTS systems, reporters must not:
+
+- Break the law or breach applicable regulations
+- Access unnecessary, excessive, or unrelated data
+- Modify or delete data
+- Perform denial-of-service or other disruptive testing
+- Use high-intensity, invasive, or destructive scanning techniques
+- Publicly disclose the vulnerability before it has been addressed
+- Attempt social engineering, Phishing, or physical attacks
+- Demand payment or compensation in exchange for disclosure
+
+These guidelines are intended to protect users, services, and data while allowing good-faith security research.
+
+
+## Bug Bounty
+
+HMCTS does not operate a paid bug bounty programme.
+
+## Code of Conduct
+
+All contributors and reporters are expected to act in good faith and in accordance with applicable laws and professional standards.
+
+## Further Reading
+
+- https://www.ncsc.gov.uk/information/vulnerability-reporting
+- https://www.gov.uk/help/report-vulnerability
+- https://github.com/Trewaters/security-README


### PR DESCRIPTION
## Summary

- Adds `SECURITY.md` to the repository root
- Content copied verbatim from [hmcts/hmcts.github.io/security.md](https://github.com/hmcts/hmcts.github.io/blob/main/security.md)
- Requested by Martyn Pope, Software Engineering Centre of Excellence

## Test plan

- [ ] Verify `SECURITY.md` appears in the repo root on GitHub
- [ ] Confirm GitHub picks it up as the repo's security policy (visible under Security tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)